### PR TITLE
added support for immutable processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # array-unique [![NPM version](https://badge.fury.io/js/array-unique.svg)](http://badge.fury.io/js/array-unique)  [![Build Status](https://travis-ci.org/jonschlinkert/array-unique.svg)](https://travis-ci.org/jonschlinkert/array-unique) 
 
-> Return an array free of duplicate values. Fastest ES5 implementation.
+> Remove duplicate values from an array. Fastest ES5 implementation.
 
 ## Install with [npm](npmjs.org)
 
@@ -13,8 +13,17 @@ npm i array-unique --save
 ```js
 var unique = require('array-unique');
 
-unique(['a', 'b', 'c', 'c']);
-//=> ['a', 'b', 'c']
+var arr = ['a', 'b', 'c', 'c'];
+console.log(unique(arr)) //=> ['a', 'b', 'c']
+console.log(arr)         //=> ['a', 'b', 'c']
+
+/* The above modifies the input array. To prevent that at a slight performance cost: */
+var unique = require("array-unique").immutable;
+
+var arr = ['a', 'b', 'c', 'c'];
+console.log(unique(arr)) //=> ['a', 'b', 'c']
+console.log(arr)         //=> ['a', 'b', 'c', 'c']
+
 ```
 
 ## Related

--- a/benchmark/code/set-immutable.js
+++ b/benchmark/code/set-immutable.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('array-uniq').immutable;

--- a/index.js
+++ b/index.js
@@ -26,3 +26,18 @@ module.exports = function unique(arr) {
   }
   return arr;
 };
+
+module.exports.immutable = function uniqueImmutable(arr) {
+  if (!Array.isArray(arr)) {
+    throw new TypeError('array-unique expects an array.');
+  }
+
+  var arrLen = arr.length;
+  var newArr = new Array(arrLen);
+
+  for (var i = 0; i < arrLen; i++) {
+    newArr[i] = arr[i];
+  }
+
+  return module.exports(newArr);
+};

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "array-unique",
-  "description": "Return an array free of duplicate values. Fastest ES5 implementation.",
-  "version": "0.2.1",
+  "description": "Remove duplicate values from an array. Fastest ES5 implementation.",
+  "version": "0.3.1",
   "homepage": "https://github.com/jonschlinkert/array-unique",
   "author": {
     "name": "Jon Schlinkert",

--- a/test.js
+++ b/test.js
@@ -40,3 +40,112 @@ describe('unique', function () {
   });
 });
 
+describe('unique.immutable', function () {
+  it('should throw an error if the value passed is not an array:', function () {
+    (function () {
+      unique.immutable('a', 'b', 'c');
+    }).should.throw('array-unique expects an array.');
+  });
+
+  it('should return an array with unique values without modifying the input:', function () {
+    (function () {
+      var original = ['a', 'b', 'c', 'a', 'b', 'd'];
+      var before =   ['a', 'b', 'c', 'a', 'b', 'd'];
+      var expected = ['a', 'b', 'c', 'd'];
+
+      unique.immutable(before).should.eql(expected);
+      before.should.eql(original);
+    })();
+
+    (function () {
+      var original = ['a', 'b', 'c', 'a', 'b', 'a', 'b', 'c', 'b', 'f', 'a', 'b'];
+      var before   = ['a', 'b', 'c', 'a', 'b', 'a', 'b', 'c', 'b', 'f', 'a', 'b'];
+      var expected = ['a', 'b', 'c', 'f'];
+
+      unique.immutable(before).should.eql(expected);
+      before.should.eql(original);
+    })();
+
+    (function () {
+      var original = ['a', 'b', 'c', 'a', 'b', 'a', 'b', 'b', 'f', 'a', 'b', 'x', 'y', 'z', 'a', 'b', 'a', 'b', 'a', 'b', 'b', 'f', 'a', 'b', 'x', 'y', 'z', 'a', 'b', 'a', 'b', 'a', 'b', 'b', 'f', 'a', 'b', 'x', 'y', 'z', 'a', 'b', 'a', 'b', 'a', 'b', 'b', 'f', 'a', 'b', 'x', 'y', 'z', 'a', 'b', 'a', 'b', 'a', 'b', 'b', 'f', 'a', 'b', 'x', 'y', 'z', 'a', 'b', 'a', 'b', 'a', 'b', 'b', 'f', 'a', 'b', 'x', 'y', 'z', 'a', 'b', 'a', 'b', 'a', 'b', 'b', 'f', 'a', 'b', 'x', 'y', 'z', 'a', 'b', 'a', 'b', 'a', 'b', 'b', 'f', 'a', 'b', 'x', 'y', 'z', 'a', 'b', 'a', 'b', 'a', 'b', 'b', 'f', 'a', 'b', 'x', 'y', 'z', 'a', 'b', 'a', 'b', 'a', 'b', 'b', 'f', 'a', 'b', 'x', 'y', 'z', 'a', 'b', 'a', 'b', 'a', 'b', 'b', 'f', 'a', 'b', 'x', 'y', 'z', 'a', 'b']
+      var before   = ['a', 'b', 'c', 'a', 'b', 'a', 'b', 'b', 'f', 'a', 'b', 'x', 'y', 'z', 'a', 'b', 'a', 'b', 'a', 'b', 'b', 'f', 'a', 'b', 'x', 'y', 'z', 'a', 'b', 'a', 'b', 'a', 'b', 'b', 'f', 'a', 'b', 'x', 'y', 'z', 'a', 'b', 'a', 'b', 'a', 'b', 'b', 'f', 'a', 'b', 'x', 'y', 'z', 'a', 'b', 'a', 'b', 'a', 'b', 'b', 'f', 'a', 'b', 'x', 'y', 'z', 'a', 'b', 'a', 'b', 'a', 'b', 'b', 'f', 'a', 'b', 'x', 'y', 'z', 'a', 'b', 'a', 'b', 'a', 'b', 'b', 'f', 'a', 'b', 'x', 'y', 'z', 'a', 'b', 'a', 'b', 'a', 'b', 'b', 'f', 'a', 'b', 'x', 'y', 'z', 'a', 'b', 'a', 'b', 'a', 'b', 'b', 'f', 'a', 'b', 'x', 'y', 'z', 'a', 'b', 'a', 'b', 'a', 'b', 'b', 'f', 'a', 'b', 'x', 'y', 'z', 'a', 'b', 'a', 'b', 'a', 'b', 'b', 'f', 'a', 'b', 'x', 'y', 'z', 'a', 'b']
+      var expected = ['a', 'b', 'c', 'f', 'x', 'y', 'z'];
+      unique.immutable(before).should.eql(expected);
+      before.should.eql(original);
+    })();
+
+    (function () {
+      var original = [
+        'foo/bar/baz/quux/fez/test/fixtures',
+        'foo/bar/baz/quux/fez/test/fixtures',
+        'foo/bar/baz/quux/fez/test/fixtures/a.js',
+        'foo/bar/baz/quux/fez/test/fixtures',
+        'foo/bar/baz/quux/fez/test/fixtures',
+        'foo/bar/baz/quux/fez/test/fixtures/b.js',
+        'foo/bar/baz/quux/fez/test/fixtures/b.js',
+        'foo/bar/baz/quux/fez/test/fixtures',
+        'foo/bar/baz/quux/fez/test/fixtures',
+        'foo/bar/baz/quux/fez/test/fixtures/a.js',
+        'foo/bar/baz/quux/fez/test/fixtures/j.js',
+        'foo/bar/baz/quux/fez/test/fixtures/z.js',
+        'foo/bar/baz/quux/fez/test/fixtures/c.js',
+        'foo/bar/baz/quux/fez/test/fixtures/d.js',
+        'foo/bar/baz/quux/fez/test/fixtures',
+        'foo/bar/baz/quux/fez/test/fixtures/a.js',
+        'foo/bar/baz/quux/fez/test/fixtures',
+        'foo/bar/baz/quux/fez/test/fixtures/h.js',
+        'foo/bar/baz/quux/fez/test/fixtures/i.js',
+        'foo/bar/baz/quux/fez/test/fixtures/j.js',
+        'foo/bar/baz/quux/fez/test/fixtures/k.js',
+        'foo/bar/baz/quux/fez/test/fixtures/l.js',
+        'foo/bar/baz/quux/fez/test/fixtures/m.js',
+        'foo/bar/baz/quux/fez/test/fixtures',
+        'foo/bar/baz/quux/fez/test/fixtures/a.js'
+      ];
+      var before = [
+        'foo/bar/baz/quux/fez/test/fixtures',
+        'foo/bar/baz/quux/fez/test/fixtures',
+        'foo/bar/baz/quux/fez/test/fixtures/a.js',
+        'foo/bar/baz/quux/fez/test/fixtures',
+        'foo/bar/baz/quux/fez/test/fixtures',
+        'foo/bar/baz/quux/fez/test/fixtures/b.js',
+        'foo/bar/baz/quux/fez/test/fixtures/b.js',
+        'foo/bar/baz/quux/fez/test/fixtures',
+        'foo/bar/baz/quux/fez/test/fixtures',
+        'foo/bar/baz/quux/fez/test/fixtures/a.js',
+        'foo/bar/baz/quux/fez/test/fixtures/j.js',
+        'foo/bar/baz/quux/fez/test/fixtures/z.js',
+        'foo/bar/baz/quux/fez/test/fixtures/c.js',
+        'foo/bar/baz/quux/fez/test/fixtures/d.js',
+        'foo/bar/baz/quux/fez/test/fixtures',
+        'foo/bar/baz/quux/fez/test/fixtures/a.js',
+        'foo/bar/baz/quux/fez/test/fixtures',
+        'foo/bar/baz/quux/fez/test/fixtures/h.js',
+        'foo/bar/baz/quux/fez/test/fixtures/i.js',
+        'foo/bar/baz/quux/fez/test/fixtures/j.js',
+        'foo/bar/baz/quux/fez/test/fixtures/k.js',
+        'foo/bar/baz/quux/fez/test/fixtures/l.js',
+        'foo/bar/baz/quux/fez/test/fixtures/m.js',
+        'foo/bar/baz/quux/fez/test/fixtures',
+        'foo/bar/baz/quux/fez/test/fixtures/a.js'
+      ];
+      var expected = [
+        'foo/bar/baz/quux/fez/test/fixtures',
+        'foo/bar/baz/quux/fez/test/fixtures/a.js',
+        'foo/bar/baz/quux/fez/test/fixtures/b.js',
+        'foo/bar/baz/quux/fez/test/fixtures/j.js',
+        'foo/bar/baz/quux/fez/test/fixtures/z.js',
+        'foo/bar/baz/quux/fez/test/fixtures/c.js',
+        'foo/bar/baz/quux/fez/test/fixtures/d.js',
+        'foo/bar/baz/quux/fez/test/fixtures/h.js',
+        'foo/bar/baz/quux/fez/test/fixtures/i.js',
+        'foo/bar/baz/quux/fez/test/fixtures/k.js',
+        'foo/bar/baz/quux/fez/test/fixtures/l.js',
+        'foo/bar/baz/quux/fez/test/fixtures/m.js'
+      ];
+
+      unique.immutable(before).should.eql(expected);
+      before.should.eql(original);
+    })();
+  });
+});


### PR DESCRIPTION
I needed to run this lib against an array that I should not modify. I added a new function `unique.immutable` that keeps all semantics of `unique` except it doesn't modify the input array. Performance will be slightly lessened but not enough to matter in my case.
